### PR TITLE
Use an append-only log to store "commands"

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -4,15 +4,15 @@
 #include "commands.h"
 #include "controller.h"
 
-command_stack_t *init_command_stack(void) {
-  command_stack_t *cs = malloc(sizeof(command_stack_t));
+command_log_t *init_command_log(void) {
+  command_log_t *cs = malloc(sizeof(command_log_t));
   cs->top = NULL;
   cs->bottom = NULL;
 
   return cs;
 }
 
-void destroy_command_stack(command_stack_t *cs) {
+void destroy_command_log(command_log_t *cs) {
   command_t *c = cs->bottom, *tmp;
 
   while (c) {
@@ -37,10 +37,7 @@ bool is_nav_command(command_t *c) {
   return t == HANDLE_MOVE || t == HANDLE_MOVE_TO_EDGE;
 }
 
-// -------------------------
-// -- History Stack methods
-// -------------------------
-command_t *append_command(command_stack_t *cs, command_t *c) {
+command_t *append_command(command_log_t *cs, command_t *c) {
   // assert valid state
   assert((!cs->top && !cs->bottom) || (cs->top && cs->bottom));
 
@@ -61,7 +58,7 @@ command_t *append_command(command_stack_t *cs, command_t *c) {
   return c;
 }
 
-command_t *pop_command(command_stack_t *cs) {
+command_t *pop_command(command_log_t *cs) {
   assert((!cs->top && !cs->bottom) || (cs->top && cs->bottom));
 
   if (!cs->top && !cs->bottom) {

--- a/src/commands.h
+++ b/src/commands.h
@@ -28,21 +28,21 @@ typedef struct command {
   struct command *prev;
 } command_t;
 
-typedef struct command_stack {
+typedef struct command_log {
   struct command *bottom;
   struct command *top;
-} command_stack_t;
+} command_log_t;
 
-command_stack_t *init_command_stack(void);
+command_log_t *init_command_log(void);
 
-void destroy_command_stack(command_stack_t *cs);
+void destroy_command_log(command_log_t *);
 
 command_t *init_command(COMMAND_TYPE t, COMMAND_PAYLOAD p);
 
-bool is_nav_command(command_t *c);
+bool is_nav_command(command_t *);
 
-command_t *append_command(command_stack_t *cs, command_t *c);
+command_t *append_command(command_log_t *cs, command_t *c);
 
-command_t *pop_command(command_stack_t *cs);
+command_t *pop_command(command_log_t *cs);
 
 #endif

--- a/src/controller.c
+++ b/src/controller.c
@@ -185,7 +185,7 @@ static void dispatch_command(state_t *st, command_t *c) {
 }
 
 void replay_history(state_t *st) {
-  command_stack_t *hs = st->hs;
+  command_log_t *hs = st->hs;
   command_t *c = hs->bottom;
 
   // TODO copy init buffer but not reconstruct it
@@ -210,8 +210,8 @@ void apply_command(state_t *st, COMMAND_TYPE t, COMMAND_PAYLOAD p) {
   dispatch_command(st, c);
 
   // FIXME kill this when implemented redo
-  destroy_command_stack(st->rs);
-  st->rs = init_command_stack();
+  destroy_command_log(st->rs);
+  st->rs = init_command_log();
 }
 
 /*

--- a/src/state.c
+++ b/src/state.c
@@ -15,9 +15,9 @@ state_t *init_state(const char *filename) {
   st->scr = init_screen(LINES);
 
   // history stack
-  st->hs = init_command_stack();
+  st->hs = init_command_log();
   // redo stack
-  st->rs = init_command_stack();
+  st->rs = init_command_log();
 
   st->status_row = init_row(NULL);
   st->prev_key = '\0';
@@ -31,8 +31,8 @@ void destroy_state(state_t *st) {
   destroy_buffer(st->buf);
   destroy_screen(st->scr);
   destroy_row(st->status_row);
-  destroy_command_stack(st->hs);
-  destroy_command_stack(st->rs);
+  destroy_command_log(st->hs);
+  destroy_command_log(st->rs);
   free(st);
 }
 

--- a/src/state.h
+++ b/src/state.h
@@ -12,8 +12,8 @@ typedef struct state {
   buffer_t *buf;
   screen_t *scr;
 
-  command_stack_t *hs;
-  command_stack_t *rs;
+  command_log_t *hs;
+  command_log_t *rs;
 
   size_t cx, cy;
   size_t top_row;

--- a/tests/commands-test.c
+++ b/tests/commands-test.c
@@ -4,8 +4,8 @@
 
 #include "../src/commands.h"
 
-static void test_command_stack(void) {
-  command_stack_t *cs = init_command_stack();
+static void test_command_log(void) {
+  command_log_t *cs = init_command_log();
   COMMAND_PAYLOAD p;
 
   COMMAND_TYPE t1 = HANDLE_APPEND_ROW;
@@ -76,11 +76,11 @@ static void test_command_stack(void) {
   assert(c1->next == NULL);
   free(tmp);
 
-  destroy_command_stack(cs);
+  destroy_command_log(cs);
 }
 
 int main(void) {
-  test_command_stack();
+  test_command_log();
 
   return 0;
 }


### PR DESCRIPTION
## Motivation
I never got `redo` working because the previous method was hard to test and reason about. This seems like a reasonable size refactor. See if it can help me to get `redo` out :slightly_smiling_face: 

https://github.com/lpan/viw/issues/34

## Context
Currently, I am trying to implement `undo` and `redo` using two mutable stacks. One stack keeps track of all the applied "commands", the other is used as a temp buffer.

When an user action is committed, we would "push" it to the first stack. When the user undoes, we would "pop" the first stack (history stack), re-apply what is now on the first stack, and push the popped "command" onto the temp stack (redo stack).

For redo, we simply pop the redo stack, then apply the command and push it back to the history stack.

In my opinion, Mutating two logs is hard to reason about than just keeping track of the offsets of an append-only log.

## What this PR does
This PR attempts to get rid of the two mutable stacks, and just use a **single** append-only log to store "commands" instead. We will use "offsets" of the log to implement the undo/redo logic.